### PR TITLE
[Packaging] internal packages

### DIFF
--- a/falcon_utils.egg-info/PKG-INFO
+++ b/falcon_utils.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.1
 Name: falcon-utils
-Version: 0.0.1
+Version: 0.0.2
 Summary: Falcon Utilities, Middlewares, Error Classes
 Home-page: UNKNOWN
 Author: Develper Junio

--- a/falcon_utils.egg-info/SOURCES.txt
+++ b/falcon_utils.egg-info/SOURCES.txt
@@ -6,3 +6,9 @@ falcon_utils.egg-info/dependency_links.txt
 falcon_utils.egg-info/not-zip-safe
 falcon_utils.egg-info/requires.txt
 falcon_utils.egg-info/top_level.txt
+falcon_utils/errors/__init__.py
+falcon_utils/middlewares/__init__.py
+falcon_utils/middlewares/auth_middleware.py
+falcon_utils/middlewares/elastic_search_logging_middleware.py
+falcon_utils/middlewares/json_middleware.py
+falcon_utils/middlewares/prometheus_middleware.py

--- a/falcon_utils/__init__.py
+++ b/falcon_utils/__init__.py
@@ -1,0 +1,2 @@
+import middlewares
+import errors

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ requirements = open('./requirements.txt', 'r').read().split("\n")
 print(requirements)
 setup(
     name='falcon-utils',
-    packages=['falcon_utils'],
-    version='0.0.1',
+    packages=['falcon_utils', 'falcon_utils.middlewares', 'falcon_utils.errors'],
+    version='0.0.2',
     author="Develper Junio",
     author_email='developer@junio.in',
     classifiers=[


### PR DESCRIPTION
Internal modules weren't added to package heirarchy, and not importable post install. Fixes added for it, by adding internal modules to package list in setup.py